### PR TITLE
Adding PHP 8.0 support #31 #32 #33

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ PHP selector for centos 6/7
 
 # RUN AT YOUR OWN RISK
 
-This install php 5.4, 5.5, 5.6, 7.0, 7.1, 7.2, 7.3 and 7.4alpha in your centos 6 and centos 7
+This install php 5.4, 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4 and 8.0 in your centos 6 and centos 7
 
 **Use sk-php-selector2.sh, in this you can select what php version install
 sk-php-selector3.sh is same as sk-php-selector2.sh but with simplified code, now in testing **

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ sk-php-selector3.sh is same as sk-php-selector2.sh but with simplified code, now
 
 bash sk-php-selector2.sh php72
 
+bash sk-php-selector2.sh php80
+
 # Or install multiple version
 
 bash sk-php-selector2.sh php56 php71

--- a/sk-php-selector.sh
+++ b/sk-php-selector.sh
@@ -15,10 +15,6 @@ exit 2
 fi
 # fix php 7 version detection...
 vp=$(php -v |head -n1 |cut -c5)
-echo "óóóóóóó"
-tput vp
-echo vp
-echo "óóóóóóó"
 if [ "$vp" -eq 5 ];then
 	actual=$(php -v| head -n1 | grep --only-matching --perl-regexp "5\.\\d+")
 elif [ "$vp" -eq 7 ];then

--- a/sk-php-selector.sh
+++ b/sk-php-selector.sh
@@ -15,16 +15,50 @@ exit 2
 fi
 # fix php 7 version detection...
 vp=$(php -v |head -n1 |cut -c5)
+echo "óóóóóóó"
+tput vp
+echo vp
+echo "óóóóóóó"
 if [ "$vp" -eq 5 ];then
 	actual=$(php -v| head -n1 | grep --only-matching --perl-regexp "5\.\\d+")
 elif [ "$vp" -eq 7 ];then
 	actual=$(php -v| head -n1 | grep --only-matching --perl-regexp "7\.\\d+")
+elif [ "$vp" -eq 8 ];then
+	actual=$(php -v| head -n1 | grep --only-matching --perl-regexp "8\.\\d+")
 else
 echo "Cant get actual php versión"
 echo "Run php -v and ask on forum or yo@skamasle.com"
 echo "Leaving instalation..."
 exit 4
 fi
+
+function phpinstall8 () {
+ver=8.0
+if [ $actual = $ver ];then
+echo "Skip PHP 8.0 actually installed"
+else
+tput setaf 2
+echo "Installing PHP 8.0"
+yum install -y php80-php-imap php80-php-process php80-php-pspell php80-php-xml php80-php-xmlrpc php80-php-pdo php80-php-ldap php80-php-pecl-zip php80-php-common php80-php php80-php-mcrypt php80-php-gmp php80-php-mysqlnd php80-php-mbstring php80-php-gd php80-php-tidy php80-php-pecl-memcache --enablerepo=remi  >> $sklog
+echo "......."
+
+# Temporary source on my personal Github repo.
+curl -s https://raw.githubusercontent.com/samaphp/sk-php-selector/master/sk-php80-centos.sh > /usr/local/vesta/data/templates/web/httpd/sk-php80.sh
+
+ln -s /usr/local/vesta/data/templates/web/httpd/phpfcgid.stpl /usr/local/vesta/data/templates/web/httpd/sk-php80.stpl
+
+ln -s /usr/local/vesta/data/templates/web/httpd/phpfcgid.tpl /usr/local/vesta/data/templates/web/httpd/sk-php80.tpl  
+
+ln -s /etc/opt/remi/php80/php.ini /etc/php80.ini
+
+ln -s  /etc/opt/remi/php80/php.d /etc/php80.d
+
+chmod +x /usr/local/vesta/data/templates/web/httpd/sk-php80.sh
+tput setaf 1
+echo "PHP 8.0 Ready!"
+tput sgr0 
+fi
+}
 
 function phpinstall7 () {
 ver=7.0
@@ -206,6 +240,7 @@ tput sgr0
 	phpinstall7
 	phpinstall71
 	phpinstall72
+	phpinstall8
 echo "################################"
 echo "Aditional PHP versión installed!"
 echo "More info on skamasle.com or vestacp forums."

--- a/sk-php-selector2.sh
+++ b/sk-php-selector2.sh
@@ -15,6 +15,8 @@ if [ "$vp" -eq 5 ];then
 	actual=$(php -v| head -n1 | grep --only-matching --perl-regexp "5\.\\d+")
 elif [ "$vp" -eq 7 ];then
 	actual=$(php -v| head -n1 | grep --only-matching --perl-regexp "7\.\\d+")
+elif [ "$vp" -eq 8 ];then
+	actual=$(php -v| head -n1 | grep --only-matching --perl-regexp "8\.\\d+")
 else
 echo "Cant get actual php versión"
 echo "Run php -v and ask on forum or yo@skamasle.com"
@@ -23,7 +25,8 @@ exit 4
 fi
 
 fixit () {
-curl -s https://raw.githubusercontent.com/Skamasle/sk-php-selector/master/sk-php${1}-centos.sh > /usr/local/vesta/data/templates/web/httpd/sk-php${1}.sh
+# Temporary the resource from my personal Github repo.
+curl -s https://raw.githubusercontent.com/samaphp/sk-php-selector/master/sk-php${1}-centos.sh > /usr/local/vesta/data/templates/web/httpd/sk-php${1}.sh
 ln -s /usr/local/vesta/data/templates/web/httpd/phpfcgid.stpl /usr/local/vesta/data/templates/web/httpd/sk-php${1}.stpl
 ln -s /usr/local/vesta/data/templates/web/httpd/phpfcgid.tpl /usr/local/vesta/data/templates/web/httpd/sk-php${1}.tpl 
 if [ -e /etc/opt/remi/php${1}/php.ini ]; then
@@ -35,6 +38,19 @@ chmod +x /usr/local/vesta/data/templates/web/httpd/sk-php${1}.sh
 tput setaf 1
 echo "PHP ${1} Ready!"
 tput sgr0
+}
+function phpinstall80 () {
+ver=8.0
+if [ $actual = $ver ];then
+echo "Skip PHP 8.0 actually installed"
+else
+tput setaf 2
+echo "Installing PHP 8.0"
+yum install -y php80-php-imap php80-php-process php80-php-pspell php80-php-xml php80-php-xmlrpc php80-php-pdo php80-php-ldap php80-php-pecl-zip php80-php-common php80-php php80-php-mcrypt php80-php-gmp php80-php-mysqlnd php80-php-mbstring php80-php-gd php80-php-tidy php80-php-pecl-memcache --enablerepo=remi  >> $sklog
+echo "......."
+
+fixit 80
+fi
 }
 function phpinstall70 () {
 ver=7.0
@@ -154,6 +170,7 @@ tput sgr0
 	phpinstall72
     phpinstall73
     phpinstall74
+    phpinstall80
 }
 usage () {
 tput setaf 1
@@ -168,7 +185,7 @@ tput sgr0
 echo "bash $0 all"
 tput setaf 1
     echo "###############################################"
-	echo "Supported Versions: 54, 55, 56, 70, 71, 72, 73"
+	echo "Supported Versions: 54, 55, 56, 70, 71, 72, 73, 80"
     echo "###############################################"
 tput sgr0
 }
@@ -199,6 +216,7 @@ tput sgr0
 			php72) phpinstall72 ;;
             php73) phpinstall73 ;;
             php74) phpinstall74 ;;
+            php80) phpinstall80 ;;
 			all) all ;;
 	  esac
 done

--- a/sk-php-selector3.sh
+++ b/sk-php-selector3.sh
@@ -15,6 +15,8 @@ if [ "$vp" -eq 5 ];then
 	actual=$(php -v| head -n1 | grep --only-matching --perl-regexp "5\.\\d+")
 elif [ "$vp" -eq 7 ];then
 	actual=$(php -v| head -n1 | grep --only-matching --perl-regexp "7\.\\d+")
+elif [ "$vp" -eq 8 ];then
+	actual=$(php -v| head -n1 | grep --only-matching --perl-regexp "8\.\\d+")
 else
 echo "Cant get actual php version"
 echo "Run php -v and ask on forum or yo@skamasle.com"
@@ -23,7 +25,8 @@ exit 4
 fi
 
 fixit () {
-curl -s https://raw.githubusercontent.com/Skamasle/sk-php-selector/master/sk-php${1}-centos.sh > /usr/local/vesta/data/templates/web/httpd/sk-php${1}.sh
+# Temporary the resource from my personal Github repo.
+curl -s https://raw.githubusercontent.com/samaphp/sk-php-selector/master/sk-php${1}-centos.sh > /usr/local/vesta/data/templates/web/httpd/sk-php${1}.sh
 if [ ! -e /usr/local/vesta/data/templates/web/httpd/sk-php${1}.stpl ]; then
     ln -s /usr/local/vesta/data/templates/web/httpd/phpfcgid.stpl /usr/local/vesta/data/templates/web/httpd/sk-php${1}.stpl
 fi
@@ -72,6 +75,7 @@ tput sgr0
     installit 72 7.2
     installit 73 7.3
     installit 74 7.4
+    installit 80 8.0
 }
 usage () {
 tput setaf 1
@@ -86,7 +90,7 @@ tput sgr0
 echo "bash $0 all"
 tput setaf 1
     echo "###############################################"
-	echo "Supported Versions: 54, 55, 56, 70, 71, 72, 73"
+	echo "Supported Versions: 54, 55, 56, 70, 71, 72, 73, 80"
     echo "###############################################"
 tput sgr0
 }
@@ -117,6 +121,7 @@ tput sgr0
 			php72) installit 72 7.2 ;;
             php73) installit 73 7.3 ;;
             php74) installit 74 7.4 ;;
+            php80) installit 80 8.0 ;;
 			all) all ;;
 	  esac
 done

--- a/sk-php80-centos.sh
+++ b/sk-php80-centos.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Adding php wrapper
+user="$1"
+domain="$2"
+ip="$3"
+home_dir="$4"
+docroot="$5"
+
+wrapper_script="#!/bin/sh
+PHPRC=/usr/local/lib
+export PHPRC
+export PHP_FCGI_MAX_REQUESTS=500
+export PHP_FCGI_CHILDREN=10
+exec  /usr/bin/php80-cgi
+"
+wrapper_file="$home_dir/$user/web/$domain/cgi-bin/fcgi-starter"
+
+echo "$wrapper_script" > $wrapper_file
+chown $user:$user $wrapper_file
+chmod -f 751 $wrapper_file
+
+exit 0


### PR DESCRIPTION
I've added support for PHP 8.0 to resolve #31 #32 #33

You will be able to support PHP 8 using this script (RUN AT YOUR OWN RISK):
`bash sk-php-selector2.sh php80`

I believe this change may support even any other PHP 8.x versions if you will use the script 3 `sk-php-selector3.sh` since it is built to be dynamic.

Please review my PR. I've tested it on my server and it works fine on my CentOS 7.9. Screenshot attached below:

![Screenshot 2021-01-22 at 19 47 49](https://user-images.githubusercontent.com/531627/105519672-be50c880-5cea-11eb-9448-34c2fbec119b.png)

![Screenshot 2021-01-22 at 20 00 16](https://user-images.githubusercontent.com/531627/105521108-89de0c00-5cec-11eb-8c15-22dfb4ddcef8.png)
